### PR TITLE
Added `lower` filter to normalize extensions

### DIFF
--- a/focalpointfield/templates/input.twig
+++ b/focalpointfield/templates/input.twig
@@ -1,5 +1,5 @@
 {% if elementType=='asset' %}
-	{% if element.getExtension() in ['jpg', 'jpeg', 'gif', 'svg', 'png'] %}
+	{% if element.getExtension()|lower in ['jpg', 'jpeg', 'gif', 'svg', 'png'] %}
 	<div class="focalpointfield-wrapper">
 		<img src="{{ element.getUrl() }}" title="{{ 'Click image to set focal point' | t }}" draggable="false">
 	</div>


### PR DESCRIPTION
Sometimes designers are crazy and they use extensions like 'photo.JPG' instead of 'photo.jpg'. Fixing this madness.
