### PR TITLE
Fixed some minor issues

### DIFF
--- a/focalpointfield/resources/js/focalpoint.js
+++ b/focalpointfield/resources/js/focalpoint.js
@@ -63,9 +63,10 @@
 			var imageHeight = $focalpointWrapper.outerHeight();
 			var posX = pageX-parentOffset.left;
 			var posY = pageY-parentOffset.top;
-			
-			var percentX = Math.round((posX/imageWidth)*100);
-			var percentY = Math.round((posY/imageHeight)*100);
+
+			var precision = Math.pow(10, 2);
+			var percentX = Math.round((posX/imageWidth)*100*precision) / precision;
+			var percentY = Math.round((posY/imageHeight)*100*precision) / precision;
 
 			percentX = Math.max(0, Math.min(percentX, 100));
 			percentY = Math.max(0, Math.min(percentY, 100));

--- a/focalpointfield/resources/js/focalpoint.js
+++ b/focalpointfield/resources/js/focalpoint.js
@@ -66,7 +66,10 @@
 			
 			var percentX = Math.round((posX/imageWidth)*100);
 			var percentY = Math.round((posY/imageHeight)*100);
-			
+
+			percentX = Math.max(0, Math.min(percentX, 100));
+			percentY = Math.max(0, Math.min(percentY, 100));
+
 			setValue(percentX, percentY);
 		}
 

--- a/focalpointfield/templates/input.twig
+++ b/focalpointfield/templates/input.twig
@@ -1,7 +1,7 @@
 {% if elementType=='asset' %}
 	{% if element.getExtension()|lower in ['jpg', 'jpeg', 'gif', 'svg', 'png'] %}
 	<div class="focalpointfield-wrapper">
-		<img src="{{ element.getUrl() }}" title="{{ 'Click image to set focal point' | t }}" draggable="false">
+		<img src="{{ element.getUrl() }}" width="300" title="{{ 'Click image to set focal point' | t }}" draggable="false">
 	</div>
 	<input type="hidden" name="{{ name }}" class="focalpointfield-field-data" value="{{ value!=null ? value : '' }}">
 	{% else %}


### PR DESCRIPTION
- `Improved` Reduced jagged dragging by allowing higher focus point position precision.
- `Fixed` Fixed bug where you could drag the focus point outside the image.
- `Fixed` Fixed issue where the image would momentarily be oversized. Sometimes when opening the asset editor modal for the first time, the image would fill the screen almost entirely for a split second, before being resized. Adding the width parameter is a quick fix for this.
